### PR TITLE
Pause/play pressing player anywhere by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ allprojects {
 | onStart                 | Callback for when the start button is pressed.                                              |
 | onPlayPress             | Callback for when the play button is pressed.                                               |
 | onHideControls          | Callback for when the controls are being hide.                                              |
-| onShowControls          | Callback for when the controls are being shown.                                             |
+| onShowControls          | Callback for when the controls are being shown.           
+| onThumbnailError        | Callback for when the thumnail image fails to load                                  |
 | customStyles            | The player can be customized in this object, see customStyles for the options.              |
 
 All other props are passed to the react-native-video component.

--- a/index.js
+++ b/index.js
@@ -526,7 +526,6 @@ export default class VideoPlayer extends Component {
       video,
       style,
       resizeMode,
-      pauseOnPress,
       fullScreenOnLongPress,
       customStyles,
       ...props
@@ -563,8 +562,7 @@ export default class VideoPlayer extends Component {
             style={styles.overlayButton}
             onPress={() => {
               this.showControls();
-              if (pauseOnPress)
-                this.onPlayPress();
+              this.onPlayPress();
             }}
             onLongPress={() => {
               if (fullScreenOnLongPress && Platform.OS !== 'android')
@@ -626,7 +624,6 @@ VideoPlayer.propTypes = {
   hideControlsOnStart: PropTypes.bool,
   endWithThumbnail: PropTypes.bool,
   disableSeek: PropTypes.bool,
-  pauseOnPress: PropTypes.bool,
   fullScreenOnLongPress: PropTypes.bool,
   customStyles: PropTypes.shape({
     wrapper: ViewPropTypesVar.style,
@@ -667,7 +664,6 @@ VideoPlayer.defaultProps = {
   loop: false,
   resizeMode: 'contain',
   disableSeek: false,
-  pauseOnPress: false,
   fullScreenOnLongPress: false,
   customStyles: {},
   showDuration: false

--- a/index.js
+++ b/index.js
@@ -415,7 +415,7 @@ export default class VideoPlayer extends Component {
   }
 
   renderThumbnail(thumbnail) {
-    const { style, customStyles, ...props } = this.props;
+    const { style, customStyles, onThumbnailError, ...props } = this.props;
     return (
       <BackgroundImage
         {...props}
@@ -426,6 +426,7 @@ export default class VideoPlayer extends Component {
           customStyles.thumbnail,
         ]}
         source={thumbnail}
+        onError={onThumbnailError}
       >
         {this.renderStartButton()}
       </BackgroundImage>


### PR DESCRIPTION
Hello, thanks for such a fantastic library!

Currently, pausing/playing when pressing anywhere in the video player is not the default option (we have to add `pauseOnPress` prop). I think this feature should be the default option. 

Let me know if any other change should be taken into consideration.