### PR TITLE
feat: thumbnail image custom styles

### DIFF
--- a/docs/docs/api/styles.md
+++ b/docs/docs/api/styles.md
@@ -49,7 +49,10 @@ The `react-native-video-player` component allows you to customize its appearance
 - **Description**: Styles the background of the seek bar.
 
 ### `thumbnail`
-- **Description**: Styles the video thumbnail shown before playback starts.
+- **Description**: Styles the video thumbnail container shown before playback starts.
+
+### `thumbnailImage`
+- **Description**: Styles the video thumbnail image shown before playback starts.
 
 ### `playButton`
 - **Description**: Styles the start button overlaying the thumbnail.
@@ -81,6 +84,7 @@ const App = () => (
         wrapper: styles.wrapper,
         playControl: styles.playControl,
         seekBarKnob: styles.seekBarKnob,
+        thumbnailImage: styles.thumbnailImage
       }}
     />
   </View>
@@ -94,6 +98,10 @@ const styles = StyleSheet.create({
     // ...
   },
   seekBarKnob: {
+    // ...
+  },
+  thumbnailImage: {
+    resizeMode: 'contain',
     // ...
   },
 });

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -29,6 +29,11 @@ const App = () => {
           thumbnail={{
             uri: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg',
           }}
+          customStyles={{
+            thumbnailImage: {
+              resizeMode: 'cover',
+            },
+          }}
           // pauseOnPress={true}
           // autoplay={true}
           // repeat={true}

--- a/src/Thumbnail.tsx
+++ b/src/Thumbnail.tsx
@@ -20,6 +20,7 @@ interface ThumbnailProps extends StartButtonProps {
   sizeStyles: { height: number; width: number };
   onStart: () => void;
   customStylesThumbnail: CustomStyles['thumbnail'];
+  customStylesThumbnailImage: CustomStyles['thumbnailImage'];
   customStylesPlayButton: CustomStyles['playButton'];
   customStylesPlayArrow: CustomStyles['playArrow'];
 }
@@ -49,12 +50,14 @@ export const Thumbnail = memo(
     sizeStyles,
     onStart,
     customStylesThumbnail,
+    customStylesThumbnailImage,
     customStylesPlayButton,
     customStylesPlayArrow,
   }: ThumbnailProps) => {
     return (
       <ImageBackground
         source={thumbnailSource}
+        imageStyle={customStylesThumbnailImage}
         style={[styles.thumbnail, sizeStyles, style, customStylesThumbnail]}
       >
         <StartButton

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,6 +47,7 @@ export interface CustomStyles {
   seekBarKnobSeeking?: StyleProp<ViewStyle>;
   seekBarBackground?: StyleProp<ViewStyle>;
   thumbnail?: StyleProp<ViewStyle>;
+  thumbnailImage?: StyleProp<ImageStyle>;
   playButton?: StyleProp<ViewStyle>;
   playArrow?: StyleProp<ImageStyle>;
   durationText?: StyleProp<TextStyle>;
@@ -146,8 +147,8 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
     }, [onEnd, endWithThumbnail, endThumbnail, setIsStarted, setHasEnded]);
 
     const onLayout = useCallback((event: LayoutChangeEvent) => {
-      const { width } = event.nativeEvent.layout;
-      setWidth(width);
+      const { width: containerWidth } = event.nativeEvent.layout;
+      setWidth(containerWidth);
     }, []);
 
     const renderContent = useCallback(() => {
@@ -161,6 +162,7 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
             sizeStyles={sizeStyles}
             onStart={_onStart}
             customStylesThumbnail={customStyles.thumbnail}
+            customStylesThumbnailImage={customStyles.thumbnailImage}
             customStylesPlayButton={customStyles.playButton}
             customStylesPlayArrow={customStyles.playArrow}
           />


### PR DESCRIPTION
## Summary

There is now a new `customStyles` property that can be passed to the video player component: `thumbnailImage`. This is required because `react-native-video-player` uses the `ImageBackground` component from `react-native` to render the thumbnail image. The `ImageBackground` component has two separate props for styles: `style` and `imageStyle`. The `resizeMode` can only be passed to the `ImageBackground` component via the `imageStyle` prop, not the `style` prop (as it was being passed previously).

NOTE: When using the `react-native-video-player` component in my app, I noticed that currently TypeScript incorrectly reports that the type of `customStyles.thumbnail` is `ImageStyle`, but it is actually defined as `ViewStyle` in `index.tsx`. I think that maybe the `index.d.ts` file needs to be generated again in order to make sure the types are correct in the npm package.

fixes #231 

### Motivation

When I was using `react-native-video-player` in my app, I noticed that when I passed `resizeMode` via the `customStyles.thumbnail` prop, the `resizeMode` was not being applied.

### Changes

- Added a `customStyles.thumbnailImage` property and passed this to the `Thumbnail` `ImageBackground` component as `imageStyle` prop.
- Updated docs with the new `customStyle.thumbnailImage` property.
- Added `customStyles.thumbnailImage` to example app (`resizeMode: 'cover'`).
- Also fixed conflicting variable name `width` in `onLayout` function in `src/index.ts`.

## Test plan
To manually test, run the example app and notice that the thumbnail covers the entire video container:

![resizeMode - cover](https://github.com/user-attachments/assets/2240ea9b-deca-47d1-9ae3-7e23b0b07a43)

Then change `customStyles.thumbnailImage.resizeMode` to "contain", and notice that the thumbnail no longer covers the entire container:

![resizeMode - contain](https://github.com/user-attachments/assets/21114315-1fde-49c8-b236-d5f46e5f5ede)

I don't think an automated test is required for this change.